### PR TITLE
Server/client communication protocol implementation

### DIFF
--- a/protocol-documentation.md
+++ b/protocol-documentation.md
@@ -7,9 +7,9 @@ Every message that is sent between the client and the server must be in the form
 
 ```json
 {
-    type: "<unique description of request/response>",
-    payload: {
-        data
+    "type": "<unique description of request/response>",
+    "payload": {
+        "data": []
     }
 }
 ```

--- a/protocol-documentation.md
+++ b/protocol-documentation.md
@@ -17,20 +17,22 @@ Every message that is sent between the client and the server must be in the form
 # Client messages
 Messages that are sent from a client to the server.
 
+### Update position
 When the position or zoom on the client's map is changed, this message should be sent to the server so that only information about busses that can be seen are sent to the client.
 ```json
 {
     "type": "geo-position-update",
     "payload": {
-        "radius": 10,
+        "maxDistance": 1000,
         "position": {
-            "latitude": 59,
-            "longitude": 16
+            "type": "Point",
+            "coordinates": [56.133, 13.128],
         }
     }
 }
 ```
 
+### Get line information
 Sent to get information about a specific line.
 > Not implemented
 ```json
@@ -42,6 +44,7 @@ Sent to get information about a specific line.
 }
 ```
 
+### Reserve seat
 Sent to reserve a seat on a bus with a specific id.
 > Not implemented
 ```json
@@ -56,6 +59,7 @@ Sent to reserve a seat on a bus with a specific id.
 # Server messages
 Messages that are sent from the server to clients.
 
+### Vehicle positions
 Sends the information of all vehicles set by `geo-position-update`
 ```json
 {
@@ -81,7 +85,8 @@ Sends the information of all vehicles set by `geo-position-update`
 }
 ```
 
-Get the information from a specific line
+### Line information
+Get the information from a specific line.
 >  Not implemented
 ```json
 {
@@ -95,9 +100,9 @@ Get the information from a specific line
 				"name": "Centralstationen",
                 "lines" : [5, 11, 14],
 				"position": {
-					"latitude": 59,
-					"longitude": 16,
-				}
+                    "type": "Point",
+                    "coordinates": [56.133, 13.128],
+                }
 			},
 			...
 		]
@@ -105,7 +110,8 @@ Get the information from a specific line
 }
 ```
 
-Get the information from a specific stop
+### Stop information
+Get the information from a specific stop.
 >  Not implemented
 ```json
 {
@@ -113,10 +119,10 @@ Get the information from a specific stop
 	"payload": {
         "name": "Centralstationen",
 		"lines" : [5, 11, 14],
-		"position": {
-			"latitude": 59,
-			"longitude": 16
-		}
+        "position": {
+            "type": "Point",
+            "coordinates": [56.133, 13.128],
+        } 
 	}
 }
 ```

--- a/protocol-documentation.md
+++ b/protocol-documentation.md
@@ -1,0 +1,122 @@
+# Protocol documentation
+Early version of the protocol used for communication, subject to be changed and expanded. Not all messages are implemented.
+
+# Format of messages
+
+Every message that is sent between the client and the server must be in the format described below. The `type` field describes what type of request/response is being sent, and the `payload` value contains whatever data is associated with that message. Important to note here is that payload can have many different types, i.e it can be an object, array or a specific value. Please look at the specification for each individual message to know what data the payload contains.
+
+```json
+{
+    type: "<unique description of request/response>",
+    payload: {
+        data
+    }
+}
+```
+
+# Client messages
+Messages that are sent from a client to the server.
+
+When the position or zoom on the client's map is changed, this message should be sent to the server so that only information about busses that can be seen are sent to the client.
+```json
+{
+    "type": "geo-position-update",
+    "payload": {
+        "radius": 10,
+        "position": {
+            "latitude": 59,
+            "longitude": 16
+        }
+    }
+}
+```
+
+Sent to get information about a specific line.
+> Not implemented
+```json
+{
+    "type": "get-line-info",
+    "payload": {
+        "line": 5
+    }
+}
+```
+
+Sent to reserve a seat on a bus with a specific id.
+> Not implemented
+```json
+{
+    "type": "reserve-seat",
+    "payload": {
+        "id": 123456
+    }
+}
+```
+
+# Server messages
+Messages that are sent from the server to clients.
+
+Sends the information of all vehicles set by `geo-position-update`
+```json
+{
+    "type": "vehicle-positions",
+    "payload": {
+        "timestamp": 111111,
+        "vehicles": [
+            {
+                "id": 123456,
+                "line": 5,
+                "capacity": 80,
+                "passengers": 30,
+                "position": {
+                    "latitude": 59,
+                    "longitude": 16,
+                    "bearing": 180,
+                    "speed": 30
+                }
+            },
+            ...
+        ]
+    }
+}
+```
+
+Get the information from a specific line
+>  Not implemented
+```json
+{
+	"type": "line-info",
+	"payload": {
+		"timestamp": 111111,
+		"line" : 5,
+    	"vehicles": 10,
+        "stops": [
+			{
+				"name": "Centralstationen",
+                "lines" : [5, 11, 14],
+				"position": {
+					"latitude": 59,
+					"longitude": 16,
+				}
+			},
+			...
+		]
+	}
+}
+```
+
+Get the information from a specific stop
+>  Not implemented
+```json
+{
+	"type": "stop-info",
+	"payload": {
+        "name": "Centralstationen",
+		"lines" : [5, 11, 14],
+		"position": {
+			"latitude": 59,
+			"longitude": 16
+		}
+	}
+}
+```

--- a/server/src/client.rs
+++ b/server/src/client.rs
@@ -1,0 +1,44 @@
+//! Information about individual clients that the lobby needs to keep track of.
+
+use uuid::Uuid;
+
+use crate::gtfs::transit_realtime::Position;
+use crate::lobby::Socket;
+
+/// Used to represent the positon of a client on their map. This is used to determined
+/// what data should be sent to the client depending on what can be seen on their
+/// map.
+#[derive(Debug)]
+pub struct ClientPosition {
+    pub radius: i32,
+    pub position: Position,
+}
+
+/// State for a WebsocketClient. Holds information specific to each connection.
+#[derive(Debug)]
+pub struct ClientData {
+    // Unique id.
+    pub id: Uuid,
+
+    // An address to communicate with the client actor.
+    pub addr: Socket,
+
+    // Where the client is currently positioned on their map. Used to send
+    // relevant data to each individual client.
+    pub position: Option<ClientPosition>,
+}
+
+impl ClientData {
+    /// Constructs a new client with no position.
+    pub fn new(id: Uuid, addr: Socket) -> Self {
+        ClientData {
+            id,
+            addr,
+            position: None,
+        }
+    }
+
+    pub fn update_position(&mut self, position: ClientPosition) {
+        self.position = Some(position);
+    }
+}

--- a/server/src/client.rs
+++ b/server/src/client.rs
@@ -2,17 +2,8 @@
 
 use uuid::Uuid;
 
-use crate::gtfs::transit_realtime::Position;
 use crate::lobby::Socket;
-
-/// Used to represent the positon of a client on their map. This is used to determined
-/// what data should be sent to the client depending on what can be seen on their
-/// map.
-#[derive(Debug)]
-pub struct ClientPosition {
-    pub radius: i32,
-    pub position: Position,
-}
+use crate::protocol::client_protocol::GeoPosition;
 
 /// State for a WebsocketClient. Holds information specific to each connection.
 #[derive(Debug)]
@@ -25,7 +16,7 @@ pub struct ClientData {
 
     // Where the client is currently positioned on their map. Used to send
     // relevant data to each individual client.
-    pub position: Option<ClientPosition>,
+    pub position: Option<GeoPosition>,
 }
 
 impl ClientData {
@@ -38,7 +29,7 @@ impl ClientData {
         }
     }
 
-    pub fn update_position(&mut self, position: ClientPosition) {
+    pub fn update_position(&mut self, position: GeoPosition) {
         self.position = Some(position);
     }
 }

--- a/server/src/lobby.rs
+++ b/server/src/lobby.rs
@@ -1,19 +1,27 @@
 use std::collections::HashMap;
+use std::time::Duration;
 
 use actix::prelude::{Actor, Context, Handler, Recipient};
+use actix::AsyncContext;
 use uuid::Uuid;
 
+use crate::client::{ClientData, ClientPosition};
 use crate::gtfs::trafiklab::TrafiklabApi;
-use crate::messages::{Connect, Disconnect, WsMessage};
+use crate::messages::{Connect, Disconnect, PositionUpdate, WsMessage};
+use crate::protocol::server_protocol::{ServerOutput, Vehicle, VehiclePositionsOutput};
+
+// The interval in which data is fetched from the external Trafiklab API and
+// echoed out to all connected users.
+const API_FETCH_INTERVAL: Duration = Duration::from_secs(5);
 
 // Type alias, which is essentially an address to an actor which you can
 // send messages to.
-type Socket = Recipient<WsMessage>;
+pub type Socket = Recipient<WsMessage>;
 
 // The lobby keeps track of a common/shared state between all clients.
 pub struct Lobby {
     // Maps client IDs to a Socket.
-    sessions: HashMap<Uuid, Socket>,
+    clients: HashMap<Uuid, ClientData>,
 
     // Handle to communicate with Trafiklab's API.
     trafiklab: TrafiklabApi,
@@ -21,42 +29,105 @@ pub struct Lobby {
 
 impl Lobby {
     pub fn new(api_key: &str) -> Self {
-        Lobby {
-            sessions: HashMap::new(),
+        let mut lobby = Lobby {
+            clients: HashMap::new(),
             trafiklab: TrafiklabApi::new(api_key),
-        }
+        };
+
+        lobby
+            .trafiklab
+            .fetch_vehicle_positions()
+            .expect("Could not fetch data from Trafiklab.");
+
+        lobby
+    }
+
+    // Returns POSIX timestamp in seconds since 1970-01-01 00:00:00.
+    fn get_current_timestamp() -> u64 {
+        let start = std::time::SystemTime::now();
+        let since_epoch_start = start.duration_since(std::time::UNIX_EPOCH).unwrap();
+
+        since_epoch_start.as_secs()
+    }
+
+    // This method starts an interval which fetches new data from the Trafiklab API,
+    // (TODO: inserts it into the database), and sends new data out to all connected
+    // clients.
+    fn start_echo_positions_interval(&mut self, ctx: &mut <Self as Actor>::Context) {
+        ctx.run_interval(API_FETCH_INTERVAL, |act, _| {
+            // TODO: Fetch data from the Trafiklab API (uncomment the line below and handle
+            // any errors correctly).
+            //act.trafiklab.fetch_vehicle_positions();
+
+            let vehicle_data = act.trafiklab.get_vehicle_positions().unwrap();
+
+            // TODO: Insert data into the database.
+
+            // TODO: Instead of collecting all data in a big chunk like this,
+            // the data should be tailored depending on what buses the user can see
+            // in regards to their "position". (Probably best done by querying MongoDB
+            // and sending the result from the query to the user).
+
+            let vehicle_positions = vehicle_data
+                .entity
+                .iter()
+                .map(|entity| Vehicle {
+                    id: entity.id.to_string(),
+                    position: entity
+                        .vehicle
+                        .as_ref()
+                        .unwrap()
+                        .position
+                        .as_ref()
+                        .unwrap()
+                        .clone(),
+                })
+                .collect();
+
+            act.send_to_everyone(
+                &serde_json::to_string(&ServerOutput::VehiclePositions(VehiclePositionsOutput {
+                    timestamp: Lobby::get_current_timestamp(),
+                    positions: vehicle_positions,
+                }))
+                .unwrap(),
+            );
+        });
     }
 }
 
 impl Lobby {
     // Sends a message to a specific client.
     fn send_message(&self, message: &str, id_to: &Uuid) {
-        if let Some(socket_recipient) = self.sessions.get(id_to) {
-            let _ = socket_recipient.do_send(WsMessage(message.to_owned()));
+        if let Some(recipient) = self.clients.get(id_to) {
+            let _ = recipient.addr.do_send(WsMessage(message.to_owned()));
         } else {
             println!("Attempting to send message but couldn't find client id.");
         }
     }
 
-    // Sends a message to every connected client stored in self.sessions.
+    // Sends a message to every connected client stored in self.clients.
     fn send_to_everyone(&self, message: &str) {
-        self.sessions
+        self.clients
             .keys()
             .for_each(|client_id| self.send_message(message, client_id));
     }
 
-    // Sends a message to every connected client stored in self.sessions.
+    // Sends a message to every connected client stored in self.clients.
     fn send_to_everyone_except_self(&self, message: &str, self_id: &Uuid) {
-        self.sessions
+        self.clients
             .keys()
             .filter(|client_id| *client_id.to_owned() != *self_id)
             .for_each(|client_id| self.send_message(message, client_id));
     }
 }
 
-// This is a blanket implementation to make sure that the Lobby type is considered an Actor.
 impl Actor for Lobby {
     type Context = Context<Self>;
+
+    // This method is when the lobby is started.
+    fn started(&mut self, ctx: &mut Self::Context) {
+        self.start_echo_positions_interval(ctx);
+    }
 }
 
 impl Handler<Connect> for Lobby {
@@ -64,8 +135,9 @@ impl Handler<Connect> for Lobby {
 
     // This method is called whenever the Lobby receives a "Connect" message.
     fn handle(&mut self, msg: Connect, _: &mut Context<Self>) {
-        // Store the address of the client in the sessions hashmap.
-        self.sessions.insert(msg.self_id, msg.addr);
+        // Store a new clien data object in the clients hashmap.
+        self.clients
+            .insert(msg.self_id, ClientData::new(msg.self_id, msg.addr));
 
         // TODO: Remove this println. Only here to show that events occur.
         println!("Client with id '{}' connected.", msg.self_id);
@@ -77,10 +149,27 @@ impl Handler<Disconnect> for Lobby {
 
     // This method is called whenever the Lobby receives a "Disconnect" message.
     fn handle(&mut self, msg: Disconnect, _: &mut Context<Self>) {
-        // Try and remove the client from the sessions hashmap.
-        if self.sessions.remove(&msg.self_id).is_some() {
+        // Try and remove the client from the clients hashmap.
+        if self.clients.remove(&msg.self_id).is_some() {
             // TODO: Remove this println. Only here to show that events occur.
             println!("Client with id '{}' disconnected.", msg.self_id);
         }
+    }
+}
+
+impl Handler<PositionUpdate> for Lobby {
+    type Result = ();
+
+    // This method is called whenever the Lobby receives a "PositionUpdate" message.
+    fn handle(&mut self, msg: PositionUpdate, _: &mut Context<Self>) {
+        let client_data = self.clients.get_mut(&msg.self_id).unwrap();
+
+        println!("previous position: {:#?}", client_data);
+
+        // Update the client's position to the new position.
+        client_data.update_position(ClientPosition {
+            radius: msg.radius,
+            position: msg.position,
+        });
     }
 }

--- a/server/src/lobby.rs
+++ b/server/src/lobby.rs
@@ -5,7 +5,7 @@ use actix::prelude::{Actor, Context, Handler, Recipient};
 use actix::AsyncContext;
 use uuid::Uuid;
 
-use crate::client::{ClientData, ClientPosition};
+use crate::client::ClientData;
 use crate::gtfs::trafiklab::TrafiklabApi;
 use crate::messages::{Connect, Disconnect, PositionUpdate, WsMessage};
 use crate::protocol::server_protocol::{ServerOutput, Vehicle, VehiclePositionsOutput};
@@ -164,12 +164,9 @@ impl Handler<PositionUpdate> for Lobby {
     fn handle(&mut self, msg: PositionUpdate, _: &mut Context<Self>) {
         let client_data = self.clients.get_mut(&msg.self_id).unwrap();
 
-        println!("previous position: {:#?}", client_data);
+        println!("updated position: {:#?}", msg.position);
 
         // Update the client's position to the new position.
-        client_data.update_position(ClientPosition {
-            radius: msg.radius,
-            position: msg.position,
-        });
+        client_data.update_position(msg.position);
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,8 +1,10 @@
+mod client;
 mod config;
 mod endpoints;
 mod gtfs;
 mod lobby;
 mod messages;
+mod protocol;
 mod ws;
 
 use actix::Actor;

--- a/server/src/messages.rs
+++ b/server/src/messages.rs
@@ -1,16 +1,18 @@
 use actix::prelude::{Message, Recipient};
 use uuid::Uuid;
 
+use crate::gtfs::transit_realtime::Position;
+
 // Messages in this file is used for internal communication between different
 // actors (Lobby and WebsocketClient for example).
 
 // WebsocketClient responds to this to pipe it through to the actual client.
-#[derive(Message)]
+#[derive(Debug, Message)]
 #[rtype(result = "()")]
 pub struct WsMessage(pub String);
 
 // WebsocketClient sends this to connect to the lobby.
-#[derive(Message)]
+#[derive(Debug, Message)]
 #[rtype(result = "()")]
 pub struct Connect {
     pub addr: Recipient<WsMessage>,
@@ -18,8 +20,17 @@ pub struct Connect {
 }
 
 // WebsocketClient sends this to disconnect from the lobby.
-#[derive(Message)]
+#[derive(Debug, Message)]
 #[rtype(result = "()")]
 pub struct Disconnect {
     pub self_id: Uuid,
+}
+
+// WebsocketClient sends this to update their position (on the map in the client) in the lobby.
+#[derive(Debug, Message)]
+#[rtype(result = "()")]
+pub struct PositionUpdate {
+    pub self_id: Uuid,
+    pub radius: i32,
+    pub position: Position,
 }

--- a/server/src/messages.rs
+++ b/server/src/messages.rs
@@ -1,10 +1,9 @@
+//! Messages used for internal communication between different actors (Lobby and WebsocketClient for example).
+
 use actix::prelude::{Message, Recipient};
 use uuid::Uuid;
 
-use crate::gtfs::transit_realtime::Position;
-
-// Messages in this file is used for internal communication between different
-// actors (Lobby and WebsocketClient for example).
+use crate::protocol::client_protocol::GeoPosition;
 
 // WebsocketClient responds to this to pipe it through to the actual client.
 #[derive(Debug, Message)]
@@ -31,6 +30,5 @@ pub struct Disconnect {
 #[rtype(result = "()")]
 pub struct PositionUpdate {
     pub self_id: Uuid,
-    pub radius: i32,
-    pub position: Position,
+    pub position: GeoPosition,
 }

--- a/server/src/protocol/client_protocol.rs
+++ b/server/src/protocol/client_protocol.rs
@@ -1,9 +1,7 @@
+//! This files declares all possible values that the client should be able
+//! to send as JSON to the server.
+
 use serde::{Deserialize, Serialize};
-
-use crate::gtfs::transit_realtime::Position;
-
-/// This files declares all possible values that the client should be able
-/// to send as JSON to the server.
 
 /// This is all possible inputs the server should be able to receive from a
 /// client. Every enumerated value in this type must have a:
@@ -15,15 +13,29 @@ use crate::gtfs::transit_realtime::Position;
 #[serde(tag = "type", content = "payload")]
 pub enum ClientInput {
     #[serde(rename = "geo-position-update")]
-    GeoPositionUpdate(GeoPositionInput),
+    GeoPositionUpdate(GeoPosition),
 }
 
-// Position data from the client.
+/// Position data from the client. Contains maximum distance and a position.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct GeoPositionInput {
-    // The radius is the maximum distance (in metres) from the clients position
-    // on their map.
-    pub radius: i32,
-    pub position: Position,
+pub struct GeoPosition {
+    // The maximum distance (in metres) from the clients position on their map that information
+    // should be gathered from.
+    pub max_distance: i32,
+
+    // The client's position.
+    pub position: GeoPositionPoint,
+}
+
+/// GeoJSON "Point" representation, see https://geojson.org/ for more details.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GeoPositionPoint {
+    // Cannot name the struct field "type" since that is a reserved keyword in rust.
+    #[serde(rename = "type")]
+    pub position_type: String,
+
+    // The vector usuaully only have two values [longitude, latitude].
+    pub coordinates: Vec<f32>,
 }

--- a/server/src/protocol/client_protocol.rs
+++ b/server/src/protocol/client_protocol.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+
+use crate::gtfs::transit_realtime::Position;
+
+/// This files declares all possible values that the client should be able
+/// to send as JSON to the server.
+
+/// This is all possible inputs the server should be able to receive from a
+/// client. Every enumerated value in this type must have a:
+///
+///     #[serde(rename = "json_key_name")]
+///
+/// before the value declaration.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload")]
+pub enum ClientInput {
+    #[serde(rename = "geo-position-update")]
+    GeoPositionUpdate(GeoPositionInput),
+}
+
+// Position data from the client.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GeoPositionInput {
+    // The radius is the maximum distance (in metres) from the clients position
+    // on their map.
+    pub radius: i32,
+    pub position: Position,
+}

--- a/server/src/protocol/mod.rs
+++ b/server/src/protocol/mod.rs
@@ -1,2 +1,4 @@
+//! Protocol messages that the client and server send to each other.
+
 pub mod client_protocol;
 pub mod server_protocol;

--- a/server/src/protocol/mod.rs
+++ b/server/src/protocol/mod.rs
@@ -1,0 +1,2 @@
+pub mod client_protocol;
+pub mod server_protocol;

--- a/server/src/protocol/server_protocol.rs
+++ b/server/src/protocol/server_protocol.rs
@@ -1,9 +1,9 @@
+//! This files declares all possible values that the server should be able
+//! to output/send as JSON to the client.
+
 use serde::{Deserialize, Serialize};
 
 use crate::gtfs::transit_realtime::Position;
-
-/// This files declares all possible values that the server should be able
-/// to output/send as JSON to the client.
 
 /// This is all possible output the server should be able to send to the
 /// client. Every enumerated value in this type must have a:
@@ -18,7 +18,7 @@ pub enum ServerOutput {
     VehiclePositions(VehiclePositionsOutput),
 }
 
-// Represent a list of vehicles.
+/// Represent a list of vehicles.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct VehiclePositionsOutput {
@@ -27,7 +27,7 @@ pub struct VehiclePositionsOutput {
     pub positions: Vec<Vehicle>,
 }
 
-// Represent a vehicle with an ID and a position.
+/// Represent a vehicle with an ID and a position.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Vehicle {
@@ -35,7 +35,7 @@ pub struct Vehicle {
     pub position: Position,
 }
 
-// Represent a list of vehicles.
+/// Represent a list of vehicles.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Line {

--- a/server/src/protocol/server_protocol.rs
+++ b/server/src/protocol/server_protocol.rs
@@ -1,0 +1,55 @@
+use serde::{Deserialize, Serialize};
+
+use crate::gtfs::transit_realtime::Position;
+
+/// This files declares all possible values that the server should be able
+/// to output/send as JSON to the client.
+
+/// This is all possible output the server should be able to send to the
+/// client. Every enumerated value in this type must have a:
+///
+///     #[serde(rename = "json_key_name")]
+///
+/// before the value declaration.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload")]
+pub enum ServerOutput {
+    #[serde(rename = "vehicle-positions")]
+    VehiclePositions(VehiclePositionsOutput),
+}
+
+// Represent a list of vehicles.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VehiclePositionsOutput {
+    // Timestamp is POSIX TIME (seconds since 1970-01-01 00:00:00).
+    pub timestamp: u64,
+    pub positions: Vec<Vehicle>,
+}
+
+// Represent a vehicle with an ID and a position.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Vehicle {
+    pub id: String,
+    pub position: Position,
+}
+
+// Represent a list of vehicles.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Line {
+    pub timestamp: String,
+    pub line: String,
+    pub vehicles: i32,
+    pub stops: Vec<Stop>,
+}
+
+// Represent a vehicle with an ID and a position.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Stop {
+    pub id: String,
+    pub lines: Vec<i32>,
+    pub position: Position,
+}

--- a/server/src/ws.rs
+++ b/server/src/ws.rs
@@ -131,8 +131,7 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WebsocketClient {
                             // Send information to the lobby that the position should be updated.
                             self.lobby_addr.do_send(PositionUpdate {
                                 self_id: self.id,
-                                radius: inp.radius,
-                                position: inp.position,
+                                position: inp,
                             });
                         }
                     }

--- a/server/src/ws.rs
+++ b/server/src/ws.rs
@@ -5,7 +5,8 @@ use actix_web_actors::ws;
 use uuid::Uuid;
 
 use crate::lobby::Lobby;
-use crate::messages::{Connect, Disconnect, WsMessage};
+use crate::messages::{Connect, Disconnect, PositionUpdate, WsMessage};
+use crate::protocol::client_protocol::ClientInput;
 
 // How often heartbeat pings are sent.
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
@@ -119,13 +120,27 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WebsocketClient {
             }
             Ok(ws::Message::Nop) => (),
             Ok(ws::Message::Text(text)) => {
-                // TODO: Here we should parse incoming messages (as JSON?).
-                // It could also be useful to send messages to the lobby here in
-                // order to echo out to all connected clients of some event at a
-                // later point in time.
+                // Try to parse the text received as a JSON representation of a ClientInput object.
+                let parse_result = serde_json::from_str::<ClientInput>(&text);
 
-                // For now we echo back to the user what they've sent.
-                ctx.text(text);
+                // Check if the parsing was sucessful.
+                if let Ok(parsed_input) = parse_result {
+                    // If it was successful, pattern match on what type of input was received.
+                    match parsed_input {
+                        ClientInput::GeoPositionUpdate(inp) => {
+                            // Send information to the lobby that the position should be updated.
+                            self.lobby_addr.do_send(PositionUpdate {
+                                self_id: self.id,
+                                radius: inp.radius,
+                                position: inp.position,
+                            });
+                        }
+                    }
+                } else {
+                    // TODO: If the message sent by the client is not parseable as JSON, an error message
+                    // should be sent back to the user.
+                    ctx.text("error");
+                }
             }
 
             // TODO: Change this panic to something else (log and disconnect?).


### PR DESCRIPTION
The protocol in its entirety is described in `protocol-documentation.md`, which *must* be updated if changes to the protocol have been made in the future. This is to make sure that everyone is on the same page regarding what messages are defined and what data to send/expect.

The server can receive a `geo-position-update`, which informs the server of an updated position for the client's map, which can be used to only send relevant information to the client in the future.

An event loop in the server has been implemented to fetch data from trafiklab and echo it out to all clients every `5` seconds. This is meant to be changed in  the future when communication with the database has been established.

The file `client.rs` has also been created, which defines two useful datatypes: `ClientPosition` and `ClientData`, which are meant to be used to keep metadata about every connected client in the lobby.

Closes #8, closes #16