### PR TITLE
Hotfix for "realtime" position update on the server.

### DIFF
--- a/server/src/gtfs/trafiklab.rs
+++ b/server/src/gtfs/trafiklab.rs
@@ -1,8 +1,10 @@
-use crate::gtfs::transit_realtime::FeedMessage;
+use std::str::from_utf8;
+
 use curl::easy::Easy;
 use quick_protobuf::{BytesReader, MessageRead};
 use serde::{Deserialize, Serialize};
-use std::str::from_utf8;
+
+use crate::gtfs::transit_realtime::FeedMessage;
 
 /// The data the Trafiklab provides in their "GTFS Regional Realtime (Beta)" API is
 /// Protocol Buffer data, it needs to be decompressed and then parsed into human-readable data
@@ -48,6 +50,9 @@ impl TrafiklabApi {
     /// To retrieve the data that was fetched, use `get_vehicle_positions()`.
     /// If Err(reason) is returned, reason is the error reason sent back by the Trafiklab API.
     pub fn fetch_vehicle_positions(&mut self) -> Result<(), String> {
+        // Clear any previous data stored in the local buffer.
+        self.raw_data.clear();
+
         let mut handle = Easy::new();
         handle
             .url(&format!("{}{}", TRAFIKLAB_API_URL, self.api_key))

--- a/server/src/lobby.rs
+++ b/server/src/lobby.rs
@@ -34,6 +34,7 @@ impl Lobby {
             trafiklab: TrafiklabApi::new(api_key),
         };
 
+        // Fetch initial data.
         lobby
             .trafiklab
             .fetch_vehicle_positions()
@@ -55,9 +56,15 @@ impl Lobby {
     // clients.
     fn start_echo_positions_interval(&mut self, ctx: &mut <Self as Actor>::Context) {
         ctx.run_interval(API_FETCH_INTERVAL, |act, _| {
-            // TODO: Fetch data from the Trafiklab API (uncomment the line below and handle
-            // any errors correctly).
-            //act.trafiklab.fetch_vehicle_positions();
+            // TODO: Fetch data from the Trafiklab API (uncomment the lines below).
+            /*
+            if act.trafiklab.fetch_vehicle_positions().is_err() {
+                println!("Failed to retrieve data from Trafiklab Realtime API. API Down?");
+
+                // Important to return since we do not have any data to send to the clients.
+                return;
+            }
+            */
 
             let vehicle_data = act.trafiklab.get_vehicle_positions().unwrap();
 


### PR DESCRIPTION
Clears the internal buffer before storing new data received from Trafiklab's API.

Handles error correctly when an API call should fail in the echo loop in `lobby.rs`.