### PR TITLE
Utility for parsing Trafiklab static data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ In order for the server to work you need to create a config file in the root dir
 
 ```yml
 trafiklab_api:
-  api_key: <very secret api key>
+  realtime_key: <very secret api key>
+  static_key: <very secret api key>
 
 database:
   uri: <very secret connection uri>

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -6,9 +6,6 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dev-dependencies]
-tempdir = "0.3"
-
 [dependencies]
 actix = "0.10"
 actix-web = "3"
@@ -21,3 +18,6 @@ quick-protobuf = "0.8.0"
 curl = "0.4.35"
 yaml-rust = "0.4.5"
 mongodb = "2.0.0-alpha"
+tempdir = "0.3"
+zip = "0.5.11"
+csv = "1.1"

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -5,6 +5,9 @@ use std::path::Path;
 
 use yaml_rust::{Yaml, YamlLoader};
 
+/// The file path to the config file.
+pub const CONFIG_FILE_PATH: &str = "../config.yml";
+
 /// The YAML key where all trafiklab data is stored.
 /// Example:
 ///
@@ -14,6 +17,7 @@ use yaml_rust::{Yaml, YamlLoader};
 
 const TRAFIKLAB_YAML_KEY: &str = "trafiklab_api";
 const DATABASE_YAML_KEY: &str = "database";
+
 /// Stores the parsed contents of a YAML config file.
 pub struct Config {
     documents: Vec<Yaml>,

--- a/server/src/gtfs/mod.rs
+++ b/server/src/gtfs/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod trafiklab;
 pub mod transit_realtime;
+pub mod transit_static;

--- a/server/src/gtfs/transit_static.rs
+++ b/server/src/gtfs/transit_static.rs
@@ -1,0 +1,155 @@
+//! Structs for parsing data in Trafiklab's Static API.
+//!
+//! The structs defined in this moduel can be used to extract data from Trafiklab's Static API
+//! (https://www.trafiklab.se/api/gtfs-regional-static-data-beta).
+//!
+//! Here is an example of how you might go about parsing one of these datasets (in CSV format), using the
+//! [csv](https://docs.rs/csv/1.1.6/csv/) crate:
+//! ```edition2018
+//! use csv::Reader;
+//!
+//! {
+//!     let trips = File::open("./agency.txt").unwrap();
+//!
+//!     let mut rdr = Reader::from_reader(trips);
+//!     let mut iter = rdr.deserialize();
+//!
+//!     // Iterates over every CSV record in "agency.txt"
+//!     while let Some(result) = iter.next() {
+//!         let record: Agency = result.unwrap();
+//!
+//!         println!("{:?}", record);
+//!     }
+//! }
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+/// Represents an agency from Trafiklab's Static API.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Agency {
+    pub agency_id: String,
+    pub agency_name: String,
+    pub agency_url: String,
+    pub agency_timezone: String,
+    pub agency_lang: String,
+    pub agency_fare_url: Option<String>,
+}
+
+/// Represents an attribution (trip_id to organization) from Trafiklab's Static API.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Attributions {
+    pub trip_id: String,
+    pub organization_name: String,
+    pub is_operator: u8,
+}
+
+/// Represents a calendar from Trafiklab's Static API.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Calendar {
+    pub service_id: u8,
+    pub monday: u8,
+    pub tuesday: u8,
+    pub wednesday: u8,
+    pub thursday: u8,
+    pub friday: u8,
+    pub saturday: u8,
+    pub sunday: u8,
+    pub start_date: String,
+    pub end_date: String,
+}
+
+/// Represents a calendar date from Trafiklab's Static API.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CalendarDates {
+    pub service_id: String,
+    pub date: String,
+    pub exception_type: u8,
+}
+
+/// Represents feed information from Trafiklab's Static API.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FeedInfo {
+    pub feed_id: String,
+    pub feed_publisher_name: String,
+    pub feed_publisher_url: String,
+    pub feed_lang: String,
+    pub feed_version: String,
+}
+
+/// Represents a route from Trafiklabs Static API.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Route {
+    pub route_id: String,
+    pub agency_id: String,
+
+    /// When both route_short_name and route_long_name have a value, the value for route_long_name should be seen
+    /// as the correct name for that line. The value of route_short_name should, when route_long_name is Some, be
+    /// seen as an alternative for systems that cannot show route_long_name.
+    pub route_short_name: String,
+    pub route_long_name: Option<String>,
+
+    pub route_type: u16,
+
+    /// Example: "Stadsbuss", "Regionbuss", "Sjukresebuss" etc.
+    pub route_desc: Option<String>,
+}
+
+/// Represents a shape from Trafiklab's Static API.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Shape {
+    pub shape_id: String,
+    pub shape_pt_lat: String,
+    pub shape_pt_lon: String,
+    pub shape_pt_sequence: u32,
+    pub shape_dist_traveled: Option<f64>,
+}
+
+/// Represents a stop time from Trafiklab's Static API.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StopTime {
+    pub trip_id: String,
+    pub arrival_time: String,
+    pub departure_time: String,
+    pub stop_id: String,
+    pub stop_sequence: u32,
+    pub stop_headsign: String,
+    pub pickup_type: u8,
+    pub drop_off_type: u8,
+    pub shape_dist_traveled: Option<f64>,
+    pub timepoint: u8,
+}
+
+/// Represents a stop from Trafiklab's Static API.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Stop {
+    pub stop_id: String,
+    pub stop_name: String,
+    pub stop_lat: String,
+    pub stop_lon: String,
+    pub location_type: u8,
+    pub parent_station: Option<String>,
+    pub platform_code: Option<String>,
+}
+
+/// Represents a transfer from Trafiklab's Static API.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Transfer {
+    pub from_stop_id: String,
+    pub to_stop_id: String,
+    pub transfer_type: u8,
+    pub min_transfer_time: Option<String>,
+    pub from_trip_id: String,
+    pub to_trip_id: String,
+}
+
+/// Represents a trip from Trafiklabs Static API.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Trip {
+    pub route_id: String,
+    pub service_id: u8,
+    pub trip_id: String,
+    pub trip_headsign: Option<String>,
+    pub direction_id: u8,
+    pub shape_id: u8,
+}

--- a/server/src/lobby.rs
+++ b/server/src/lobby.rs
@@ -74,24 +74,26 @@ impl Lobby {
     /// This method starts an interval which fetches new data from the Trafiklab API.
     fn start_echo_positions_interval(&mut self, ctx: &mut <Self as Actor>::Context) {
         ctx.run_interval(API_FETCH_INTERVAL, |act, _| {
-            // TODO: Fetch data from the Trafiklab API (uncomment the lines below).
-            /*
-            if act.trafiklab.fetch_vehicle_positions().is_err() {
-                println!("Failed to retrieve data from Trafiklab Realtime API. API Down?");
+            // Fetch vehicle positions from Trafiklab's API.
+            match act.trafiklab.fetch_vehicle_positions() {
+                Err(reason) => {
+                    println!(
+                        "Failed to retrieve data from Trafiklab Realtime API. Reason: {}",
+                        reason
+                    );
 
-                // Important to return since we do not have any data to send to the clients.
-                return;
+                    // TODO: Send error message to clients indicating that the server cannot receive
+                    // data from the external API.
+                    return;
+                }
+                Ok(()) => (),
             }
-            */
 
             let vehicle_data = act.trafiklab.get_vehicle_positions().unwrap();
 
-            // TODO: Insert data into the database.
-
             // TODO: Instead of collecting all data in a big chunk like this,
             // the data should be tailored depending on what buses the user can see
-            // in regards to their "position". (Probably best done by querying MongoDB
-            // and sending the result from the query to the user).
+            // in regards to their "position".
 
             let vehicle_positions = vehicle_data
                 .entity

--- a/server/src/ws.rs
+++ b/server/src/ws.rs
@@ -153,7 +153,7 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WebsocketClient {
 
             // If the message sent by the client is invalid (should rarely
             // happen in theory), we panic (exit the program).
-            Err(e) => panic!(e),
+            Err(e) => panic!("{}", e),
         }
     }
 }


### PR DESCRIPTION
Main addition is `gtfs/transit_static.rs`, which contains all structures for parsing any static data received from Trafiklab's static API.

Two methods: `fetch_static_data` and `delete_static_data` has been added to `gtfs/trafiklab.rs` so support for fetching and deleting the static data. *A method for getting the fetched data has not yet been added and is on our todo list.

Since the static api uses a different key than the realtime api does, a new field has been added in the `config.yml` in `README.md` to have two different keys: `realtime_key` and `static_key`.

The parsing of the api keys has been moved to the constructor for the `Lobby` in order to minimize clutter in the main function and a lot of arguments flying around.

Closes #26 

 