### PR TITLE
Communication protocol update, route information and protocol fixes

### DIFF
--- a/protocol-documentation.md
+++ b/protocol-documentation.md
@@ -110,7 +110,7 @@ Get the information from a specific line.
         "stops": [
             {
                 "name": "Centralstationen",
-                "lines" : [5, 11, 14],
+                "lines" : ["5", "11", "14"],
                 "position": {
                     "type": "Point",
                     "coordinates": [56.133, 13.128],

--- a/protocol-documentation.md
+++ b/protocol-documentation.md
@@ -39,7 +39,19 @@ Sent to get information about a specific line.
 {
     "type": "get-line-info",
     "payload": {
-        "line": 5
+        "line": "5"
+    }
+}
+```
+
+### Get route information
+Sent to get information about a specific route.
+> Not implemented
+```json
+{
+    "type": "get-route-info",
+    "payload": {
+        "line": "5"
     }
 }
 ```
@@ -51,7 +63,7 @@ Sent to reserve a seat on a bus with a specific id.
 {
     "type": "reserve-seat",
     "payload": {
-        "id": 123456
+        "id": "123456"
     }
 }
 ```
@@ -68,8 +80,8 @@ Sends the information of all vehicles set by `geo-position-update`
         "timestamp": 111111,
         "vehicles": [
             {
-                "id": 123456,
-                "line": 5,
+                "id": "123456",
+                "line": "5",
                 "capacity": 80,
                 "passengers": 30,
                 "position": {
@@ -93,7 +105,7 @@ Get the information from a specific line.
 	"type": "line-info",
 	"payload": {
 		"timestamp": 111111,
-		"line" : 5,
+		"line" : "5",
     	"vehicles": 10,
         "stops": [
 			{
@@ -110,6 +122,26 @@ Get the information from a specific line.
 }
 ```
 
+### Route information
+Get the coordinates for a specific route.
+>  Not implemented
+```json
+{
+	"type": "route-info",
+	"payload": {
+		"timestamp": 111111,
+		"line" : "5",
+    	"routeId": "123456",
+        "route": [
+			{lat: 37.772, lng: -122.214},
+			{lat: 21.291, lng: -157.821},
+			{lat: -18.142, lng: 178.431},
+			{lat: -27.467, lng: 153.027}
+		]
+	}
+}
+```
+
 ### Stop information
 Get the information from a specific stop.
 >  Not implemented
@@ -118,7 +150,7 @@ Get the information from a specific stop.
 	"type": "stop-info",
 	"payload": {
         "name": "Centralstationen",
-		"lines" : [5, 11, 14],
+		"lines" : ["5", "11", "14"],
         "position": {
             "type": "Point",
             "coordinates": [56.133, 13.128],

--- a/protocol-documentation.md
+++ b/protocol-documentation.md
@@ -102,23 +102,23 @@ Get the information from a specific line.
 >  Not implemented
 ```json
 {
-	"type": "line-info",
-	"payload": {
-		"timestamp": 111111,
-		"line" : "5",
-    	"vehicles": 10,
+    "type": "line-info",
+    "payload": {
+        "timestamp": 111111,
+        "line" : "5",
+        "vehicles": 10,
         "stops": [
-			{
-				"name": "Centralstationen",
+            {
+                "name": "Centralstationen",
                 "lines" : [5, 11, 14],
-				"position": {
+                "position": {
                     "type": "Point",
                     "coordinates": [56.133, 13.128],
                 }
-			},
-			...
-		]
-	}
+            },
+            ...
+        ]
+    }
 }
 ```
 
@@ -127,18 +127,18 @@ Get the coordinates for a specific route.
 >  Not implemented
 ```json
 {
-	"type": "route-info",
-	"payload": {
-		"timestamp": 111111,
-		"line" : "5",
-    	"routeId": "123456",
+    "type": "route-info",
+    "payload": {
+        "timestamp": 111111,
+        "line" : "5",
+        "routeId": "123456",
         "route": [
-			{lat: 37.772, lng: -122.214},
-			{lat: 21.291, lng: -157.821},
-			{lat: -18.142, lng: 178.431},
-			{lat: -27.467, lng: 153.027}
-		]
-	}
+            {"lat": 37.772, "lng": -122.214},
+            {"lat": 21.291, "lng": -157.821},
+            {"lat": -18.142, "lng": 178.431},
+            {"lat": -27.467, "lng": 153.027}
+        ]
+    }
 }
 ```
 
@@ -147,14 +147,14 @@ Get the information from a specific stop.
 >  Not implemented
 ```json
 {
-	"type": "stop-info",
-	"payload": {
+    "type": "stop-info",
+    "payload": {
         "name": "Centralstationen",
-		"lines" : ["5", "11", "14"],
+        "lines" : ["5", "11", "14"],
         "position": {
             "type": "Point",
             "coordinates": [56.133, 13.128],
         } 
-	}
+    }
 }
 ```

--- a/server/src/protocol/client_protocol.rs
+++ b/server/src/protocol/client_protocol.rs
@@ -12,10 +12,10 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "type", content = "payload")]
 pub enum ClientInput {
     #[serde(rename = "get-line-info")]
-    GetLineInformation(LineInformation)
+    GetLineInformation(LineInformation),
 
     #[serde(rename = "get-route-info")]
-    GetRouteInformation(LineInformation)
+    GetRouteInformation(LineInformation),
 
     #[serde(rename = "geo-position-update")]
     GeoPositionUpdate(GeoPosition),

--- a/server/src/protocol/client_protocol.rs
+++ b/server/src/protocol/client_protocol.rs
@@ -11,8 +11,21 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload")]
 pub enum ClientInput {
+    #[serde(rename = "get-line-info")]
+    GetLineInformation(LineInformation)
+
+    #[serde(rename = "get-route-info")]
+    GetRouteInformation(LineInformation)
+
     #[serde(rename = "geo-position-update")]
     GeoPositionUpdate(GeoPosition),
+}
+
+/// Contains a line number
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LineInformation {
+    pub line: String,
 }
 
 /// Position data from the client. Contains maximum distance and a position.

--- a/server/src/protocol/server_protocol.rs
+++ b/server/src/protocol/server_protocol.rs
@@ -34,14 +34,32 @@ pub struct Vehicle {
     pub position: Position,
 }
 
-/// Represent a list of vehicles.
+/// Represent a line.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Line {
     pub timestamp: String,
     pub line: String,
-    pub vehicles: i32,
+    pub vehicles: u32,
     pub stops: Vec<Stop>,
+}
+
+/// Represent a route.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Route {
+    pub timestamp: String,
+    pub line: String,
+    pub route_id: String,
+    pub route: Vec<Coordinate>,
+}
+
+/// Represent a coordinate.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Coordinate {
+    pub lat: f32,
+    pub lng: f32,
 }
 
 // Represent a vehicle with an ID and a position.
@@ -49,6 +67,6 @@ pub struct Line {
 #[serde(rename_all = "camelCase")]
 pub struct Stop {
     pub id: String,
-    pub lines: Vec<i32>,
+    pub lines: Vec<String>,
     pub position: Position,
 }

--- a/server/src/ws.rs
+++ b/server/src/ws.rs
@@ -134,6 +134,10 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WebsocketClient {
                 if let Ok(parsed_input) = parse_result {
                     // If it was successful, pattern match on what type of input was received.
                     match parsed_input {
+                        // TODO: Handle these.
+                        ClientInput::GetLineInformation(_) => (),
+                        ClientInput::GetRouteInformation(_) => (),
+
                         ClientInput::GeoPositionUpdate(inp) => {
                             // Send information to the lobby that the position should be updated.
                             self.lobby_addr.do_send(PositionUpdate {


### PR DESCRIPTION
Update to the protocol which introduces route information and fixes inconsistencies from the protocol and implementation.

- `get-route-info` and `route-info` implemented to give route vehicles take
- `id` and `line` fields are now strings, to better match with how they are stored and make it easier to send. (this is only a change to the protocol, as they were already stored as strings)