### PR TITLE
Added inline docs, support for API_key hidden in .env file, changed v…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ server/**/*.rs.bk
 
 # Hide the config file since it contains API keys and other sensitive data.
 config.yml
+
+# Hide googlemaps api-key
+
+client/.env

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1183,6 +1183,14 @@
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "globals": {
           "version": "12.4.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -1195,6 +1203,15 @@
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
         }
       }
     },
@@ -1252,10 +1269,27 @@
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
         },
         "resolve-from": {
           "version": "5.0.0",
@@ -2395,6 +2429,12 @@
         "pretty-format": "^26.0.0"
       }
     },
+    "@types/js-yaml": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.0.tgz",
+      "integrity": "sha512-4vlpCM5KPCL5CfGmTbpjwVKbISRYhduEJvvUWsH5EB7QInhEj94XPZ3ts/9FPiLZFqYO0xoW4ZL8z2AabTGgJA==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -2949,12 +2989,9 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "aria-query": {
       "version": "4.2.2",
@@ -4783,6 +4820,14 @@
         "postcss": "^7.0.0"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "cosmiconfig": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
@@ -4792,6 +4837,17 @@
             "is-directory": "^0.3.1",
             "js-yaml": "^3.13.1",
             "parse-json": "^4.0.0"
+          },
+          "dependencies": {
+            "js-yaml": {
+              "version": "3.14.1",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+              "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+              "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+              }
+            }
           }
         },
         "import-fresh": {
@@ -5760,6 +5816,14 @@
             "color-convert": "^2.0.1"
           }
         },
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "chalk": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -5809,6 +5873,15 @@
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
         },
         "path-key": {
           "version": "3.1.1",
@@ -9709,12 +9782,11 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       }
     },
     "jsbn": {
@@ -11668,6 +11740,14 @@
         "import-cwd": "^2.0.0"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "cosmiconfig": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
@@ -11677,6 +11757,17 @@
             "is-directory": "^0.3.1",
             "js-yaml": "^3.13.1",
             "parse-json": "^4.0.0"
+          },
+          "dependencies": {
+            "js-yaml": {
+              "version": "3.14.1",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+              "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+              "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+              }
+            }
           }
         },
         "import-fresh": {
@@ -14580,6 +14671,25 @@
         "stable": "^0.1.8",
         "unquote": "~1.1.1",
         "util.promisify": "~1.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
       }
     },
     "symbol-observable": {

--- a/client/package.json
+++ b/client/package.json
@@ -11,6 +11,7 @@
     "@testing-library/react": "^11.2.6",
     "@testing-library/user-event": "^12.8.3",
     "google-map-react": "^2.1.9",
+    "js-yaml": "^4.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",
@@ -40,5 +41,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@types/js-yaml": "^4.0.0"
   }
 }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -3,6 +3,7 @@ import Map from "./map.js";
 import SearchBar from "./SearchBar.js";
 import './App.css';
 
+
 class App extends React.Component {
 
   constructor() {

--- a/client/src/map.js
+++ b/client/src/map.js
@@ -6,12 +6,15 @@ import {
   Marker,
   InfoWindow,
 } from "@react-google-maps/api";
-import { computeDistanceBetween } from 'spherical-geometry-js';
+import { computeDistanceBetween } from "spherical-geometry-js";
 import Fab from "@material-ui/core/Fab";
 import Brightness3Icon from "@material-ui/icons/Brightness3";
 import MyLocationIcon from "@material-ui/icons/MyLocation";
 import "./App.css";
 
+/*
+ * Function component for the Map of the application
+ */
 
 function Map(props) {
   const defaultLat = 59.8585;
@@ -21,25 +24,36 @@ function Map(props) {
     lng: defaultLng,
   };
   const styles = require("./mapstyle.json");
+
+  // State-variables
   const [currentTheme, setCurrentTheme] = useState(styles.day);
   const [realtimeData, setRealtimeData] = useState(props.realtimeData);
   const [currentCenter, setCurrentCenter] = useState(defaultCenter);
   const [selectedMarker, setSelectedMarker] = useState(null);
   const [markers, setMarkers] = useState([]);
 
+  // Fires a re-render to re-draw each bus on every 
+  // API-reponse recieved from the server
   useEffect(() => {
     setRealtimeData(props.realtimeData);
     setMarkers(
-      props.realtimeData.map(obj => (
+      props.realtimeData.map((bus) => (
         <Marker
-          key={obj.id}
+          key={bus.id}
           position={{
-            lat: obj.position.latitude,
-            lng: obj.position.longitude,
+            lat: bus.position.latitude,
+            lng: bus.position.longitude,
           }}
-          onClick={() => {setSelectedMarker(obj);}}
-        >
-        </Marker>
+          onClick={() => {
+            setSelectedMarker(bus);
+          }}
+          icon={{
+            url: "/bus.svg",
+            origin: new window.google.maps.Point(0, 0),
+            anchor: new window.google.maps.Point(15, 15),
+            scaledSize: new window.google.maps.Size(30, 30),
+          }}
+        ></Marker>
       ))
     );
   }, [props.realtimeData]);
@@ -79,22 +93,26 @@ function Map(props) {
 
     // return the distance along the earths surface
     return computeDistanceBetween(center, northEast);
-  }
+  };
 
   const { isLoaded, loadError } = useLoadScript({
-    googleMapsApiKey: "",
+    // Reads the google-maps api_key from your locally created .env file
+    googleMapsApiKey: process.env.REACT_APP_GOOGLE_MAPS_API_KEY,
   });
 
+  // Container size for the GoogleMap component
   const mapContainerStyle = {
     height: "100vh",
     width: "100vw",
   };
 
+  // Default options of the GoogleMap component
   const options = {
     styles: currentTheme,
     disableDefaultUI: true,
   };
 
+  // Gets the users position using the browser location
   const updateLocation = () => {
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(setCoordinates);
@@ -103,6 +121,7 @@ function Map(props) {
     }
   };
 
+  // Sets the center of the map to the user-position
   const setCoordinates = (position) => {
     setCurrentCenter({
       lat: position.coords.latitude,
@@ -110,6 +129,7 @@ function Map(props) {
     });
   };
 
+  // Changes between dark-theme and light-theme
   const changeTheme = () => {
     if (currentTheme === styles.day) {
       setCurrentTheme(styles.night);
@@ -128,7 +148,9 @@ function Map(props) {
         center={currentCenter}
         mapContainerStyle={mapContainerStyle}
         options={options}
-        onClick={()=>{setSelectedMarker(null)}}
+        onClick={() => {
+          setSelectedMarker(null);
+        }}
         onLoad={onMapLoad}
         onBoundsChanged={onBoundsChanged}
       >
@@ -170,7 +192,10 @@ function Map(props) {
       >
         <MyLocationIcon />
       </Fab>
-      <Fab color="primary" id="themeButton" onClick={changeTheme}>
+      <Fab 
+        color="primary" 
+        id="themeButton" 
+        onClick={changeTheme}>
         <Brightness3Icon />
       </Fab>
     </div>


### PR DESCRIPTION
- Added some inline docs for the client files.
- Added support for storing the Google Maps API key in a .env file (preferred way to store API keys when using create-react-app). Follow the steps listed below for setting up
- Changed a variable name from obj to bus

Setup .env file to store google maps api key:
1. cd to client directory
2. touch .env
3. In this file type `REACT_APP_GOOGLE_MAPS_API_KEY = "<Your API key>"`
4. Done!

Reason for not putting API-key in `config.yml`: I tried parsing and reading from the repos config.yml file, however there are some issues reading from local files client side when using Node, since it runs on the server. From some googling it seems like this is not the way to go when reading API-keys in React, and therefore I adopted the "best practice" way for this. 