### PR TITLE
MongoDB synchronous & "get-route-info" message.

### DIFF
--- a/protocol-documentation.md
+++ b/protocol-documentation.md
@@ -46,7 +46,6 @@ Sent to get information about a specific line.
 
 ### Get route information
 Sent to get information about a specific route.
-> Not implemented
 ```json
 {
     "type": "get-route-info",
@@ -126,7 +125,6 @@ Get the information from a specific line.
 
 ### Route information
 Get the coordinates for a specific route.
->  Not implemented
 ```json
 {
     "type": "route-info",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,7 +17,11 @@ protobuf = { version = "2", features = ["with-bytes"] }
 quick-protobuf = "0.8.0"
 curl = "0.4.35"
 yaml-rust = "0.4.5"
-mongodb = "2.0.0-alpha"
 tempdir = "0.3"
 zip = "0.5.11"
 csv = "1.1"
+
+[dependencies.mongodb]
+version = "2.0.0-alpha.1"
+default-features = false
+features = ["sync"]

--- a/server/src/database.rs
+++ b/server/src/database.rs
@@ -1,24 +1,24 @@
 //! Module for handling operations and connection to a external MongoDB database
-use mongodb::{error::Error, options::ClientOptions, Client};
+use mongodb::{error::Error, options::ClientOptions, sync::Client};
 
-///Constant of the database name that should be used
+/// Constant of the database name that should be used
 const DATABASE_NAME: &str = "haunterDB";
 
-///Our abstraction for the db, we can use method syntax for operation ex: conn.updateGeoPosition(id, value)
-pub struct Connection {
+/// Our abstraction for the db, we can use method syntax for operation ex: conn.updateGeoPosition(id, value)
+pub struct DbConnection {
     client: Client,
 }
 
-///Inititalise a connection with uri_str
-pub async fn init_connection(uri_str: &str) -> Result<Connection, mongodb::error::Error> {
-    let client_options = ClientOptions::parse(uri_str).await?;
+/// Inititalise a connection with uri_str
+pub fn init_db_connection(uri_str: &str) -> Result<DbConnection, Error> {
+    let client_options = ClientOptions::parse(uri_str)?;
     let result_client = Client::with_options(client_options)?;
-    let result = Connection {
+
+    Ok(DbConnection {
         client: result_client,
-    };
-    Ok(result)
+    })
 }
 
-impl Connection {
-    //TODO: Code for operations upon the db
+impl DbConnection {
+    // TODO: Code for operations upon the db
 }

--- a/server/src/database.rs
+++ b/server/src/database.rs
@@ -1,8 +1,17 @@
 //! Module for handling operations and connection to a external MongoDB database
-use mongodb::{error::Error, options::ClientOptions, sync::Client};
 
-/// Constant of the database name that should be used
-const DATABASE_NAME: &str = "haunterDB";
+use mongodb::bson::Document;
+use mongodb::{
+    error::Error,
+    options::ClientOptions,
+    sync::{Client, Database},
+};
+
+use crate::gtfs::transit_static::{Route, Shape, Trip};
+use crate::protocol::server_protocol::RouteNode;
+
+/// Database name for the database containing static data.
+const STATIC_DATABASE: &str = "trafiklab-static-data";
 
 /// Our abstraction for the db, we can use method syntax for operation ex: conn.updateGeoPosition(id, value)
 pub struct DbConnection {
@@ -20,5 +29,60 @@ pub fn init_db_connection(uri_str: &str) -> Result<DbConnection, Error> {
 }
 
 impl DbConnection {
-    // TODO: Code for operations upon the db
+    fn static_db(&self) -> Database {
+        self.client.database(STATIC_DATABASE)
+    }
+}
+
+impl DbConnection {
+    /// Query the database for a "route".
+    pub fn get_route(&self, query: Document) -> Result<Route, ()> {
+        if let Ok(value_option) = self.static_db().collection("routes").find_one(query, None) {
+            let row: Route = value_option.unwrap();
+
+            Ok(row)
+        } else {
+            Err(())
+        }
+    }
+
+    /// Query the database for a "trip".
+    pub fn get_trip(&self, query: Document) -> Result<Trip, ()> {
+        if let Ok(value_option) = self.static_db().collection("trips").find_one(query, None) {
+            let row: Trip = value_option.unwrap();
+
+            Ok(row)
+        } else {
+            Err(())
+        }
+    }
+
+    /// Query the database for a list of "shapes".
+    pub fn get_shapes(&self, query: Document) -> Result<Vec<RouteNode>, ()> {
+        if let Ok(cursor) = self.static_db().collection("shapes").find(query, None) {
+            // Create a vector to store all the nodes in.
+            let mut nodes = Vec::new();
+
+            for result in cursor {
+                // Each "result" in the cursor iterator is a result from a mongodb
+                // query since not all documents might be fetched at the same time.
+                if let Ok(document) = result {
+                    // Type annotate.
+                    let shape: Shape = document;
+
+                    // Store a RouteNode representation in the shapes list.
+                    nodes.push(RouteNode {
+                        lat: shape.shape_pt_lat,
+                        lng: shape.shape_pt_lon,
+                        sequence: shape.shape_pt_sequence.parse().unwrap(),
+                    });
+                }
+            }
+
+            // Return all the shapes.
+            Ok(nodes)
+        } else {
+            Err(())
+        }
+    }
 }

--- a/server/src/gtfs/transit_static.rs
+++ b/server/src/gtfs/transit_static.rs
@@ -41,20 +41,20 @@ pub struct Agency {
 pub struct Attributions {
     pub trip_id: String,
     pub organization_name: String,
-    pub is_operator: u8,
+    pub is_operator: i32,
 }
 
 /// Represents a calendar from Trafiklab's Static API.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Calendar {
-    pub service_id: u8,
-    pub monday: u8,
-    pub tuesday: u8,
-    pub wednesday: u8,
-    pub thursday: u8,
-    pub friday: u8,
-    pub saturday: u8,
-    pub sunday: u8,
+    pub service_id: i32,
+    pub monday: i32,
+    pub tuesday: i32,
+    pub wednesday: i32,
+    pub thursday: i32,
+    pub friday: i32,
+    pub saturday: i32,
+    pub sunday: i32,
     pub start_date: String,
     pub end_date: String,
 }
@@ -64,7 +64,7 @@ pub struct Calendar {
 pub struct CalendarDates {
     pub service_id: String,
     pub date: String,
-    pub exception_type: u8,
+    pub exception_type: i32,
 }
 
 /// Represents feed information from Trafiklab's Static API.
@@ -89,7 +89,7 @@ pub struct Route {
     pub route_short_name: String,
     pub route_long_name: Option<String>,
 
-    pub route_type: u16,
+    pub route_type: String,
 
     /// Example: "Stadsbuss", "Regionbuss", "Sjukresebuss" etc.
     pub route_desc: Option<String>,
@@ -101,8 +101,8 @@ pub struct Shape {
     pub shape_id: String,
     pub shape_pt_lat: String,
     pub shape_pt_lon: String,
-    pub shape_pt_sequence: u32,
-    pub shape_dist_traveled: Option<f64>,
+    pub shape_pt_sequence: String,
+    pub shape_dist_traveled: Option<String>,
 }
 
 /// Represents a stop time from Trafiklab's Static API.
@@ -112,12 +112,12 @@ pub struct StopTime {
     pub arrival_time: String,
     pub departure_time: String,
     pub stop_id: String,
-    pub stop_sequence: u32,
+    pub stop_sequence: i32,
     pub stop_headsign: String,
-    pub pickup_type: u8,
-    pub drop_off_type: u8,
+    pub pickup_type: i32,
+    pub drop_off_type: i32,
     pub shape_dist_traveled: Option<f64>,
-    pub timepoint: u8,
+    pub timepoint: i32,
 }
 
 /// Represents a stop from Trafiklab's Static API.
@@ -127,7 +127,7 @@ pub struct Stop {
     pub stop_name: String,
     pub stop_lat: String,
     pub stop_lon: String,
-    pub location_type: u8,
+    pub location_type: i32,
     pub parent_station: Option<String>,
     pub platform_code: Option<String>,
 }
@@ -137,7 +137,7 @@ pub struct Stop {
 pub struct Transfer {
     pub from_stop_id: String,
     pub to_stop_id: String,
-    pub transfer_type: u8,
+    pub transfer_type: i32,
     pub min_transfer_time: Option<String>,
     pub from_trip_id: String,
     pub to_trip_id: String,
@@ -147,9 +147,9 @@ pub struct Transfer {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Trip {
     pub route_id: String,
-    pub service_id: u8,
+    pub service_id: String,
     pub trip_id: String,
     pub trip_headsign: Option<String>,
-    pub direction_id: u8,
-    pub shape_id: u8,
+    pub direction_id: String,
+    pub shape_id: String,
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -12,8 +12,7 @@ use actix::Actor;
 use actix_web::{App, HttpServer};
 
 use crate::config::{Config, CONFIG_FILE_PATH};
-use crate::database::init_connection;
-use crate::database::Connection;
+use crate::database::init_db_connection;
 use crate::endpoints::ws_endpoint as ws_endpoint_route;
 use crate::lobby::Lobby;
 
@@ -29,10 +28,16 @@ async fn main() -> std::io::Result<()> {
 
     // Get Database URI from config
     let db_uri = config_handler.get_database_value("uri").unwrap();
-    let conn = init_connection(db_uri);
+
+    // Try to get a handle with a connection to the database, otherwise exit
+    let connection = init_db_connection(db_uri).unwrap_or_else(|reason| {
+        println!("Could not connect to database. Reason: {}", reason);
+
+        std::process::exit(1);
+    });
 
     // Create the common/shared state.
-    let lobby = Lobby::new().start();
+    let lobby = Lobby::new(connection).start();
 
     HttpServer::new(move || App::new().service(ws_endpoint_route).data(lobby.clone()))
         // The "0.0.0.0" means that the server accepts requests from any host (127.0.0.1, 192.168.x.x, etc..)

--- a/server/src/messages.rs
+++ b/server/src/messages.rs
@@ -32,3 +32,11 @@ pub struct PositionUpdate {
     pub self_id: Uuid,
     pub position: GeoPosition,
 }
+
+/// WebsocketClient sends this to request information about a line from the lobby.
+#[derive(Debug, Message)]
+#[rtype(result = "()")]
+pub struct RouteRequest {
+    pub self_id: Uuid,
+    pub line_number: String,
+}

--- a/server/src/protocol/server_protocol.rs
+++ b/server/src/protocol/server_protocol.rs
@@ -15,6 +15,9 @@ use crate::gtfs::transit_realtime::Position;
 pub enum ServerOutput {
     #[serde(rename = "vehicle-positions")]
     VehiclePositions(VehiclePositionsOutput),
+
+    #[serde(rename = "route-info")]
+    RouteInformation(RouteInformationOutput),
 }
 
 /// Represent a list of vehicles.
@@ -35,6 +38,25 @@ pub struct Vehicle {
     pub position: Position,
 }
 
+/// Represent a list of lines.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RouteInformationOutput {
+    pub timestamp: u64,
+    pub line: String,
+    pub route_id: String,
+    pub route: Vec<RouteNode>,
+}
+
+/// Represent a route node.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RouteNode {
+    pub lat: String,
+    pub lng: String,
+    pub sequence: i32,
+}
+
 /// Represent a line.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -43,16 +65,6 @@ pub struct Line {
     pub line: String,
     pub vehicles: u32,
     pub stops: Vec<Stop>,
-}
-
-/// Represent a route.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Route {
-    pub timestamp: String,
-    pub line: String,
-    pub route_id: String,
-    pub route: Vec<Coordinate>,
 }
 
 /// Represent a coordinate.

--- a/server/src/ws.rs
+++ b/server/src/ws.rs
@@ -7,7 +7,7 @@ use actix_web_actors::ws;
 use uuid::Uuid;
 
 use crate::lobby::Lobby;
-use crate::messages::{Connect, Disconnect, PositionUpdate, WsMessage};
+use crate::messages::{Connect, Disconnect, PositionUpdate, RouteRequest, WsMessage};
 use crate::protocol::client_protocol::ClientInput;
 
 /// How often heartbeat pings are sent.
@@ -136,8 +136,12 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WebsocketClient {
                     match parsed_input {
                         // TODO: Handle these.
                         ClientInput::GetLineInformation(_) => (),
-                        ClientInput::GetRouteInformation(_) => (),
-
+                        ClientInput::GetRouteInformation(inp) => {
+                            self.lobby_addr.do_send(RouteRequest {
+                                self_id: self.id,
+                                line_number: inp.line,
+                            });
+                        }
                         ClientInput::GeoPositionUpdate(inp) => {
                             // Send information to the lobby that the position should be updated.
                             self.lobby_addr.do_send(PositionUpdate {


### PR DESCRIPTION
Main new features are:
- Made MongoDB communication synchronous (instead of asynchronous).
- Added support for the "get-route-info" message from a client, that responds with information about where a "route" is mapped onto a map. See `protocol-documentation.md` for a full specification of the messages that are sent/received.

Important to note here is that functionality for requesting and inserting data into MongoDB from Trafiklab's static API has not been implemented, instead use the MongoDB URI that Carl Willman has posten in `#server-backend` as URI, since that database contains necessary data for the new features to work.

Also changed ALL unsigned types in `transit_static.rs` to signed `i32`s, since BSON does not accept unsigned integers.

I have tested this using the following shorthand command in a new tab in my browser:
```js
// Run this command before sending any messages.
let ws = new WebSocket("ws://localhost:8080/ws"); ws.onmessage = msg => console.log(JSON.parse(msg.data));

ws.send(JSON.stringify({
    type: "get-route-info",
    payload: {
        line: "1"
    }
}));
```

Closes #45 