### PR TITLE
Added Reserve/Unreserve seat and error messages

### DIFF
--- a/protocol-documentation.md
+++ b/protocol-documentation.md
@@ -14,6 +14,18 @@ Every message that is sent between the client and the server must be in the form
 }
 ```
 
+# Error message
+An error message is sent by the server if the client has sent an unknown message or bad data, if the server can't handle a request due to some reason or if the database server is down etc.
+```json
+{
+    "type": "error",
+    "payload": {
+        "error_type": "SERVER_ERROR | UNKNOWN_MESSAGE | BAD_DATA | POSITION | LINE_INFO | ROUTE_INFO | RESERVE | UNRESERVE",
+        "error_message": "<error message>",
+    }
+}
+```
+
 # Client messages
 Messages that are sent from a client to the server.
 
@@ -62,8 +74,17 @@ Sent to reserve a seat on a bus with a specific id.
 {
     "type": "reserve-seat",
     "payload": {
-        "id": "123456"
+        "descriptor_id": "123456"
     }
+}
+```
+
+### Unreserve seat
+Sent to unreserve a seat on a bus with a specific id.
+> Not implemented
+```json
+{
+    "type": "unreserve-seat"
 }
 ```
 

--- a/server/src/client.rs
+++ b/server/src/client.rs
@@ -17,15 +17,20 @@ pub struct ClientData {
     /// Where the client is currently positioned on their map. Used to send
     /// relevant data to each individual client.
     pub position: Option<GeoPosition>,
+
+    /// None if the client has not reserved a seat on a bus, Some with a descriptor_id
+    /// if the client has reserved a seat.
+    pub reserved_seat: Option<String>,
 }
 
 impl ClientData {
-    /// Constructs a new client with no position.
+    /// Constructs a new client with no position and no reserved seat.
     pub fn new(id: Uuid, addr: Socket) -> Self {
         ClientData {
             id,
             addr,
             position: None,
+            reserved_seat: None,
         }
     }
 

--- a/server/src/messages.rs
+++ b/server/src/messages.rs
@@ -33,10 +33,25 @@ pub struct PositionUpdate {
     pub position: GeoPosition,
 }
 
-/// WebsocketClient sends this to request information about a line from the lobby.
+/// WebsocketClient sends this to request information about a route from the lobby.
 #[derive(Debug, Message)]
 #[rtype(result = "()")]
 pub struct RouteRequest {
     pub self_id: Uuid,
     pub line_number: String,
+}
+
+/// WebsocketClient sends this to reserve a seat on a bus.
+#[derive(Debug, Message)]
+#[rtype(result = "()")]
+pub struct ReserveSeat {
+    pub self_id: Uuid,
+    pub descriptor_id: String,
+}
+
+/// WebsocketClient sends this to unreserve a seat on a bus.
+#[derive(Debug, Message)]
+#[rtype(result = "()")]
+pub struct UnreserveSeat {
+    pub self_id: Uuid,
 }

--- a/server/src/protocol/client_protocol.rs
+++ b/server/src/protocol/client_protocol.rs
@@ -19,6 +19,12 @@ pub enum ClientInput {
 
     #[serde(rename = "geo-position-update")]
     GeoPositionUpdate(GeoPosition),
+
+    #[serde(rename = "reserve-seat")]
+    ReserveSeat(VehicleDescriptor),
+
+    #[serde(rename = "unreserve-seat")]
+    UnreserveSeat,
 }
 
 /// Contains a line number
@@ -50,4 +56,11 @@ pub struct GeoPositionPoint {
 
     // The vector usuaully only have two values [latitude, longitude].
     pub coordinates: Vec<f32>,
+}
+
+/// Contains a vehicle descriptor id
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VehicleDescriptor {
+    pub descriptor_id: String,
 }

--- a/server/src/protocol/server_protocol.rs
+++ b/server/src/protocol/server_protocol.rs
@@ -4,6 +4,20 @@ use serde::{Deserialize, Serialize};
 
 use crate::gtfs::transit_realtime::Position;
 
+/// Defines possible errors that might occur on the server side.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ErrorType {
+    ServerError,
+    UnknownMessage,
+    BadData,
+    Position,
+    LineInfo,
+    RouteInfo,
+    Reserve,
+    Unreserve,
+}
+
 /// This is all possible output the server should be able to send to the
 /// client. Every enumerated value in this type must have a:
 ///
@@ -13,11 +27,32 @@ use crate::gtfs::transit_realtime::Position;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload")]
 pub enum ServerOutput {
+    #[serde(rename = "error")]
+    Error(ErrorOutput),
+
     #[serde(rename = "vehicle-positions")]
     VehiclePositions(VehiclePositionsOutput),
 
     #[serde(rename = "route-info")]
     RouteInformation(RouteInformationOutput),
+}
+
+impl ServerOutput {
+    pub fn error_message(error_type: ErrorType, error_message: String) -> String {
+        serde_json::to_string(&ServerOutput::Error(ErrorOutput {
+            error_type,
+            error_message,
+        }))
+        .unwrap()
+    }
+}
+
+/// Represent an error.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ErrorOutput {
+    pub error_type: ErrorType,
+    pub error_message: String,
 }
 
 /// Represent a list of vehicles.

--- a/server/src/ws.rs
+++ b/server/src/ws.rs
@@ -11,6 +11,7 @@ use crate::messages::{
     Connect, Disconnect, PositionUpdate, ReserveSeat, RouteRequest, UnreserveSeat, WsMessage,
 };
 use crate::protocol::client_protocol::ClientInput;
+use crate::protocol::server_protocol::{ErrorType, ServerOutput};
 
 /// How often heartbeat pings are sent.
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
@@ -165,10 +166,12 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WebsocketClient {
                         }
                     }
                 } else {
-                    println!("parse result: {:?}", parse_result);
-                    // TODO: If the message sent by the client is not parseable as JSON, an error message
-                    // should be sent back to the user.
-                    ctx.text("error");
+                    // If the message sent by the client is not parseable as JSON, an error message
+                    // is sent back to the user.
+                    ctx.text(ServerOutput::error_message(
+                        ErrorType::UnknownMessage,
+                        "Unsupported message".to_owned(),
+                    ));
                 }
             }
 

--- a/server/src/ws.rs
+++ b/server/src/ws.rs
@@ -7,7 +7,9 @@ use actix_web_actors::ws;
 use uuid::Uuid;
 
 use crate::lobby::Lobby;
-use crate::messages::{Connect, Disconnect, PositionUpdate, RouteRequest, WsMessage};
+use crate::messages::{
+    Connect, Disconnect, PositionUpdate, ReserveSeat, RouteRequest, UnreserveSeat, WsMessage,
+};
 use crate::protocol::client_protocol::ClientInput;
 
 /// How often heartbeat pings are sent.
@@ -152,8 +154,18 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WebsocketClient {
                                 position: inp,
                             });
                         }
+                        ClientInput::ReserveSeat(inp) => {
+                            self.lobby_addr.do_send(ReserveSeat {
+                                self_id: self.id,
+                                descriptor_id: inp.descriptor_id,
+                            });
+                        }
+                        ClientInput::UnreserveSeat => {
+                            self.lobby_addr.do_send(UnreserveSeat { self_id: self.id });
+                        }
                     }
                 } else {
+                    println!("parse result: {:?}", parse_result);
                     // TODO: If the message sent by the client is not parseable as JSON, an error message
                     // should be sent back to the user.
                     ctx.text("error");


### PR DESCRIPTION

Added functionality for handling `reserve-seat` and `unreserve-seat` in the server, however they cannot be handled properly yet since data in the database for passenger count is not stored yet.

Also added an error message described in `protocol-documentation.md` that allows for the server to send detailed responses to the client if something has gone wrong or some bad data is received.

In order for the error handling to work we've changed the `get_*` functions in `database.rs` to return an `Option` instead of a `Result`, since the MongoDB `find_one` call returns `Result<Option<T>>` which is not easily handled otherwise.

Closes #57 

Co-authored-by: caspernorrbin <caspernorrbin@users.noreply.github.com>