### PR TITLE
Can now query for shapes with trip_id & line number

### DIFF
--- a/protocol-documentation.md
+++ b/protocol-documentation.md
@@ -45,12 +45,12 @@ When the position or zoom on the client's map is changed, this message should be
 ```
 
 ### Get route information
-Sent to get information about a specific route.
+Sent to get information about a specific route. "id" can either be a line number (i.e "1", "13", "844" etc) or a trip id, in which case the response from the server will be more detailed.
 ```json
 {
     "type": "get-route-info",
     "payload": {
-        "line": "5"
+        "id": "5"
     }
 }
 ```
@@ -133,8 +133,6 @@ Get the coordinates for a specific route.
     "type": "route-info",
     "payload": {
         "timestamp": 111111,
-        "line" : "5",
-        "routeId": "123456",
         "route": [
             {"lat": 37.772, "lng": -122.214},
             {"lat": 21.291, "lng": -157.821},

--- a/server/src/messages.rs
+++ b/server/src/messages.rs
@@ -43,7 +43,7 @@ pub struct PositionUpdate {
 #[rtype(result = "()")]
 pub struct RouteRequest {
     pub self_id: Uuid,
-    pub line_number: String,
+    pub identifier: String,
 }
 
 /// WebsocketClient sends this to reserve a seat on a bus.

--- a/server/src/protocol/client_protocol.rs
+++ b/server/src/protocol/client_protocol.rs
@@ -15,7 +15,7 @@ pub enum ClientInput {
     GetLineInformation(LineInformation),
 
     #[serde(rename = "get-route-info")]
-    GetRouteInformation(LineInformation),
+    GetRouteInformation(Identifier),
 
     #[serde(rename = "geo-position-update")]
     GeoPositionUpdate(GeoPosition),
@@ -35,6 +35,14 @@ pub enum ClientInput {
 #[serde(rename_all = "camelCase")]
 pub struct LineInformation {
     pub line: String,
+}
+
+/// Contains an identifier. Typically used for cases where the identifier can have different meaning
+/// depending on the value
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Identifier {
+    pub id: String,
 }
 
 /// Position data from the client. Contains maximum distance and a position.

--- a/server/src/protocol/server_protocol.rs
+++ b/server/src/protocol/server_protocol.rs
@@ -90,8 +90,6 @@ pub struct PassengerInformationOutput {
 #[serde(rename_all = "camelCase")]
 pub struct RouteInformationOutput {
     pub timestamp: u64,
-    pub line: String,
-    pub route_id: String,
     pub route: Vec<RouteNode>,
 }
 

--- a/server/src/util.rs
+++ b/server/src/util.rs
@@ -19,3 +19,8 @@ pub fn filter_vehicle_position(client_geo: &GeoPosition, vhc: &Vehicle) -> bool 
 
     distance.meters() < client_geo.max_distance.into()
 }
+
+/// Returns true if the input string only contains numbers
+pub fn only_numbers(input: &str) -> bool {
+    input.chars().all(|c| c.is_numeric())
+}

--- a/server/src/ws.rs
+++ b/server/src/ws.rs
@@ -146,7 +146,7 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WebsocketClient {
                         ClientInput::GetRouteInformation(inp) => {
                             self.lobby_addr.do_send(RouteRequest {
                                 self_id: self.id,
-                                line_number: inp.line,
+                                identifier: inp.id,
                             });
                         }
                         ClientInput::GeoPositionUpdate(inp) => {


### PR DESCRIPTION

A `"get-route-info"` message can now be made with both a line number and a trip id.

Adjustments to the `protocol-documentation`:

`"get-route-info"` now takes an `id` instead of `line`. The `id` can be both a line number and a trip id.

`"route-info"` does no longer send back the line number and routeId for the route request.

Closes #69 